### PR TITLE
Fix boolean saved as string

### DIFF
--- a/src/Http/Controllers/SettingsToolController.php
+++ b/src/Http/Controllers/SettingsToolController.php
@@ -58,10 +58,12 @@ class SettingsToolController extends Controller
         $settings = Valuestore::make($this->settingsPath);
 
         foreach ($request->all() as $setting => $value) {
-            if ($value instanceof UploadedFile) {
-                $settingObject = $this->getSettingObject($setting);
+            $settingObject = $this->getSettingObject($setting);
 
+            if ($settingObject['type'] === 'file' && $value instanceof UploadedFile) {
                 $settings->put($setting, $value->storeAs($settingObject['path'], $value->getClientOriginalName(), $settingObject['disk']));
+            } else if ($settingObject['type'] === 'toggle') {
+                $settings->put($setting, $value === 'true');
             } else {
                 $settings->put($setting, $value);
             }
@@ -73,7 +75,8 @@ class SettingsToolController extends Controller
     /**
      * Retrieve the config for a specified key
      */
-    public function getSettingObject(string $key) {
+    public function getSettingObject(string $key)
+    {
         $settingConfig = config('settings.panels');
 
         foreach ($settingConfig as $object) {

--- a/src/Http/Controllers/SettingsToolController.php
+++ b/src/Http/Controllers/SettingsToolController.php
@@ -62,7 +62,7 @@ class SettingsToolController extends Controller
 
             if ($settingObject['type'] === 'file' && $value instanceof UploadedFile) {
                 $settings->put($setting, $value->storeAs($settingObject['path'], $value->getClientOriginalName(), $settingObject['disk']));
-            } else if ($settingObject['type'] === 'toggle') {
+            } elseif ($settingObject['type'] === 'toggle') {
                 $settings->put($setting, $value === 'true');
             } else {
                 $settings->put($setting, $value);
@@ -73,7 +73,7 @@ class SettingsToolController extends Controller
     }
 
     /**
-     * Retrieve the config for a specified key
+     * Retrieve the config for a specified key.
      */
     public function getSettingObject(string $key)
     {
@@ -86,7 +86,5 @@ class SettingsToolController extends Controller
                 }
             }
         }
-
-        return null;
     }
 }


### PR DESCRIPTION
After the changes in #19 boolean values got saved as strings. This pull request fixes this problem.
Empty text or textarea fields are already correctly saved as `null`. Please make sure the `settings.json` does not already contain the wrong value `"null"` because it will take this value if you want to update it as an empty field.