### PR TITLE
Add a metaInfo `title` to settings tool

### DIFF
--- a/resources/js/SettingsTool.vue
+++ b/resources/js/SettingsTool.vue
@@ -49,6 +49,12 @@ export default {
         TextareaSetting,
         ToggleSetting,
     },
+    
+    metaInfo() {
+        return {
+            title: 'Settings',
+        }
+    },
 
     data: () => ({
         saving: false,


### PR DESCRIPTION
This PR adds a title to the Settings Tool so the browser tab isn't `| App Name` but `Settings | App Name`.

I've not had time to test this but from looking at Nova itself this fix should do the job.